### PR TITLE
build(sdk): build a Node.JS version of `@mermaidchart/sdk`

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Compile an ESM version of this codebase for Node.JS.
+
+## [0.1.1] - 2023-09-08
+
+- Browser-only build.

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Compile an ESM version of this codebase for Node.JS.
+- Compile an ESM version of this codebase for Node.JS v18.
 
 ## [0.1.1] - 2023-09-08
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "pnpm build:code && pnpm build:types",
     "build:code": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js",
-    "build:types": "tsc -p ./tsconfig.json --emitDeclarationOnly"
+    "build:types": "tsc -p ./tsconfig.json --emitDeclarationOnly",
+    "prepare": "pnpm run build"
   },
   "keywords": [],
   "contributors": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,13 +2,18 @@
   "name": "@mermaidchart/sdk",
   "version": "0.1.1",
   "description": "Access the MermaidChart services with OAuth and type safety.",
-  "main": "dist/index.js",
+  "browser": "dist/bundle.iife.js",
+  "types": "dist/index.d.ts",
+  "main": "dist/index.mjs",
   "scripts": {
     "build": "pnpm build:code && pnpm build:types",
-    "build:code": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js",
+    "build:code": "pnpm run build:code:browser && pnpm run build:code:node",
+    "build:code:browser": "esbuild src/index.ts --bundle --minify --outfile=dist/bundle.iife.js",
+    "build:code:node": "esbuild src/index.ts --bundle --platform=node --format=esm --packages=external --minify --outfile=dist/index.mjs",
     "build:types": "tsc -p ./tsconfig.json --emitDeclarationOnly",
     "prepare": "pnpm run build"
   },
+  "type": "module",
   "keywords": [],
   "contributors": [
     "Sidharth Vinod (https://sidharth.dev)"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,11 +5,14 @@
   "browser": "dist/bundle.iife.js",
   "types": "dist/index.d.ts",
   "main": "dist/index.mjs",
+  "engines": {
+    "node": "^18.18.0 || >= 20.0.0"
+  },
   "scripts": {
     "build": "pnpm build:code && pnpm build:types",
     "build:code": "pnpm run build:code:browser && pnpm run build:code:node",
     "build:code:browser": "esbuild src/index.ts --bundle --minify --outfile=dist/bundle.iife.js",
-    "build:code:node": "esbuild src/index.ts --bundle --platform=node --format=esm --packages=external --minify --outfile=dist/index.mjs",
+    "build:code:node": "esbuild src/index.ts --bundle --platform=node --target=node18.18 --format=esm --packages=external --minify --outfile=dist/index.mjs",
     "build:types": "tsc -p ./tsconfig.json --emitDeclarationOnly",
     "prepare": "pnpm run build"
   },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,8 +2,8 @@ import { v4 as uuid } from 'uuid';
 import { OAuth2Client, generateCodeVerifier } from '@badgateway/oauth2-client';
 import defaultAxios from 'axios';
 import type { AxiosInstance, AxiosResponse } from 'axios';
-import { RequiredParameterMissingError, OAuthError } from './errors';
-import { URLS } from './urls';
+import { RequiredParameterMissingError, OAuthError } from './errors.js';
+import { URLS } from './urls.js';
 import type {
   AuthState,
   InitParams,
@@ -11,7 +11,7 @@ import type {
   MCUser,
   MCProject,
   MCDocument,
-} from './types';
+} from './types.js';
 
 const defaultBaseURL = 'https://www.mermaidchart.com'; // "http://127.0.0.1:5174"
 const authorizationURLTimeout = 60_000;

--- a/packages/sdk/src/urls.ts
+++ b/packages/sdk/src/urls.ts
@@ -1,4 +1,4 @@
-import type { MCDocument } from './types';
+import type { MCDocument } from './types.js';
 
 export const URLS = {
   oauth: {


### PR DESCRIPTION
Currently, the `@mermaidchart/sdk` package only builds an [IIFE bundle](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) for use in a browser.

Unfortunately, this doesn't work in Node.JS, so I've instead built an ESM version for Node.JS.