### PR TITLE
fix(sdk): fix `#getAuthorizationData()` default URL missing a `state` parameter

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MermaidChart#getAuthorizationData()` now correctly sets `state` in the URL
+  by default.
 - `MermaidChart#handleAuthorizationResponse()` now supports relative URLs.
 
 ## [0.1.1] - 2023-09-08

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -39,6 +39,14 @@ describe('MermaidChart', () => {
     });
   });
 
+  describe('#getAuthorizationData', () => {
+    it('should set default state', async () => {
+      const { state, url } = await client.getAuthorizationData();
+
+      expect(new URL(url).searchParams.has('state', state)).toBeTruthy();
+    });
+  });
+
   describe('#handleAuthorizationResponse', () => {
     let state: AuthorizationData['state'];
     beforeEach(async () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -83,7 +83,7 @@ export class MermaidChart {
 
     const url = await this.oauth.authorizationCode.getAuthorizeUri({
       redirectUri: this.redirectURI,
-      state,
+      state: stateID,
       codeVerifier,
       scope,
     });


### PR DESCRIPTION
**Draft PR: This PR is stacked on top of:**
  - #5, which is stacked on top of
  - #4.

**Please change this PR to target `main` once #5 has been merged.**

`getAuthorizationData()` was returning a URL without `state` when `state` was `undefined`. This was then causing the MermaidChart API to not return a `state`, causing an error in `#handleAuthorizationResponse()`:

https://github.com/Mermaid-Chart/plugins/blob/0ff60d5a90f39b1d8a6bee744e09f8988cf88bf5/packages/sdk/src/index.ts#L111-L113