### PR TITLE
test(sdk): add some basic E2E tests with `test.mermaidchart.com`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,9 @@ jobs:
       - name: Test ${{ matrix.pkg }}
         run: |
           pnpm --filter='${{ matrix.pkg }}' test
+
+      - name: E2E tests (if present) for ${{ matrix.pkg }}
+        env:
+          TEST_MERMAIDCHART_API_TOKEN: ${{ secrets.TEST_MERMAIDCHART_API_TOKEN }}
+        run: |
+          pnpm --if-present --filter='${{ matrix.pkg }}' test:e2e

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,8 @@
     "build:code:node": "esbuild src/index.ts --bundle --platform=node --target=node18.18 --format=esm --packages=external --minify --outfile=dist/index.mjs",
     "build:types": "tsc -p ./tsconfig.json --emitDeclarationOnly",
     "prepare": "pnpm run build",
-    "test": "vitest"
+    "test": "vitest src/",
+    "test:e2e": "vitest --config vitest.config.e2e.ts"
   },
   "type": "module",
   "keywords": [],
@@ -29,6 +30,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/node": "^18.18.0",
     "@types/uuid": "^9.0.2"
   },
   "publishConfig": {

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -1,0 +1,34 @@
+/**
+ * E2E tests
+ */
+import { MermaidChart } from './index.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import process from 'node:process';
+
+let client: MermaidChart;
+
+beforeAll(async() => {
+  if (!process.env.TEST_MERMAIDCHART_API_TOKEN) {
+    throw new Error(
+      "Missing required environment variable TEST_MERMAIDCHART_API_TOKEN. "
+      + "Please go to https://test.mermaidchart.com/app/user/settings and create one."
+    );
+  }
+
+  client = new MermaidChart({
+    clientID: '00000000-0000-0000-0000-000000git000test',
+    baseURL: 'https://test.mermaidchart.com',
+    redirectURI: 'https://localhost.invalid',
+  });
+
+  await client.setAccessToken(process.env.TEST_MERMAIDCHART_API_TOKEN);
+});
+
+describe('getUser', () => {
+  it("should get user", async() => {
+    const user = await client.getUser();
+
+    expect(user).toHaveProperty('emailAddress');
+  });
+});

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": [
+      "node"
+    ],
   },
   "include": ["./src/**/*.ts"]
 }

--- a/packages/sdk/vitest.config.e2e.ts
+++ b/packages/sdk/vitest.config.e2e.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ["**/*.e2e.test.ts"],
+  },
+});

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,11 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+/** only run unit tests, no e2e tests */
+export default defineConfig({
+  test: {
+    exclude: [
+      ...configDefaults.exclude,
+      "**/*.e2e.test.ts",
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
     devDependencies:
+      '@types/node':
+        specifier: ^18.18.0
+        version: 18.18.12
       '@types/uuid':
         specifier: ^9.0.2
         version: 9.0.2
@@ -662,6 +665,7 @@ packages:
   /@azure/msal-browser@2.38.2:
     resolution: {integrity: sha512-71BeIn2we6LIgMplwCSaMq5zAwmalyJR3jFcVOZxNVfQ1saBRwOD+P77nLs5vrRCedVKTq8RMFhIOdpMLNno0A==}
     engines: {node: '>=0.8.0'}
+    deprecated: A newer major version of this library is available. Please upgrade to the latest available version.
     dependencies:
       '@azure/msal-common': 13.3.0
     dev: true
@@ -679,6 +683,7 @@ packages:
   /@azure/msal-node@1.18.3:
     resolution: {integrity: sha512-lI1OsxNbS/gxRD4548Wyj22Dk8kS7eGMwD9GlBZvQmFV8FJUXoXySL1BiNzDsHUE96/DS/DHmA+F73p1Dkcktg==}
     engines: {node: 10 || 12 || 14 || 16 || 18}
+    deprecated: A newer major version of this library is available. Please upgrade to the latest available version.
     dependencies:
       '@azure/msal-common': 13.3.0
       jsonwebtoken: 9.0.2
@@ -3981,6 +3986,12 @@ packages:
     dependencies:
       '@types/node': 20.8.5
       form-data: 4.0.0
+    dev: true
+
+  /@types/node@18.18.12:
+    resolution: {integrity: sha512-G7slVfkwOm7g8VqcEF1/5SXiMjP3Tbt+pXDU3r/qhlM2KkGm786DUD4xyMA2QzEElFrv/KZV9gjygv4LnkpbMQ==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/node@20.4.2:
@@ -12771,6 +12782,10 @@ packages:
 
   /undici-types@5.25.3:
     resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /undici@5.22.1:


### PR DESCRIPTION
**Draft PR: This PR is stacked on top of:**
  - #5.

**Please change this PR to target `main` once #5 has been merged.**

In PR #5 I added some unit tests for the `@mermaidchart/sdk` package that mock communication so it works offline. However, if we really want to test if our API works, we need to have proper E2E tests with a real server.

I've added a basic E2E test with that is run with `pnpm run test:e2e` on https://test.mermaidchart.com/. These E2E tests are **not** run when doing `pnpm test`, since they're slower and need an API key.

For GitHub Actions, I've set up an API Key for a new user I created on https://test.mermaidchart.com/ called `alois+github-actions-key@mermaidchart.com`.