### PR TITLE
Add the `getDiagram(diagramID)` API function to the SDK

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -54,9 +54,9 @@ components:
         projectID:
           type: string
         major:
-          type: string
+          type: integer
         minor:
-          type: string
+          type: integer
         title:
           type: string
       required:

--- a/openapi.yml
+++ b/openapi.yml
@@ -160,6 +160,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Document'
+
+  /rest-api/documents/{documentID}:
+    get:
+      tags:
+        - document
+      summary: Gets the given diagram
+      operationId: getDocument
+      parameters:
+        - name: documentID
+          in: path
+          required: true
+          description: The ID of the document to get diagram data for
+          schema:
+            type: string
+        - name: version
+          in: query
+          required: false
+          description: |
+            The version of the document to get diagram data for.
+
+            If not set, defaults to the highest version.
+          schema:
+            type: string
+          example: v0.1
+      security:
+        - mermaidchart_auth:
+          - read
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+        '404':
+          description: File Not Found
+
   /raw/{documentID}:
     get:
       tags:

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Compile an ESM version of this codebase for Node.JS v18.
+- Add `MermaidChart#getDiagram(diagramID)` function to get a diagram.
 
 ### Fixed
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Compile an ESM version of this codebase for Node.JS v18.
 
+### Fixed
+
+- Fix `MCDocument` `major`/`minor` type to `number`.
+
 ## [0.1.1] - 2023-09-08
 
 - Browser-only build.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -180,6 +180,13 @@ export class MermaidChart {
     return url;
   }
 
+  public async getDocument(
+    document: Pick<MCDocument, 'documentID'> | Pick<MCDocument, 'documentID' | 'major' | 'minor'>,
+  ) {
+    const {data} =  await this.axios.get<MCDocument>(URLS.rest.documents.pick(document).self);
+    return data;
+  }
+
   public async getRawDocument(
     document: Pick<MCDocument, 'documentID' | 'major' | 'minor'>,
     theme: 'light' | 'dark',

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -31,8 +31,8 @@ export interface MCProject {
 export interface MCDocument {
   documentID: string;
   projectID: string;
-  major: string;
-  minor: string;
+  major: number;
+  minor: number;
   title: string;
 }
 

--- a/packages/sdk/src/urls.ts
+++ b/packages/sdk/src/urls.ts
@@ -6,6 +6,25 @@ export const URLS = {
     token: `/oauth/token`,
   },
   rest: {
+    documents: {
+      pick: (opts: Pick<MCDocument, 'documentID'> | Pick<MCDocument, 'documentID' | 'major' | 'minor'>) => {
+        const {documentID} = opts;
+        let queryParams = "";
+
+        if ('major' in opts) {
+          const {major, minor} = opts;
+
+          queryParams = `v${major ?? 0}.${minor ?? 1}`;
+        }
+
+        const baseURL = `/rest-api/documents/${documentID}`;
+        return {
+          presentations: `${baseURL}/presentations`,
+          self: baseURL,
+          withVersion: `${baseURL}${queryParams}`
+        };
+      }
+    },
     users: {
       self: `/rest-api/users/me`,
     },


### PR DESCRIPTION
**Draft PR: This PR is stacked on top of:**
  - #7, which is stacked on top of
  - #5

**Please change this PR to target `main` once #7 has been merged.**

Add support for the `getDiagram(diagramID)` API function to the SDK. I've also added it to the OpenAPI spec.

![image](https://github.com/Mermaid-Chart/plugins/assets/19716675/2ddc7175-faa4-4554-acd2-809de530987a)


