### PR TITLE
feat: add `createDocument(projectID)` API function

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -128,6 +128,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Document'
+    post:
+      tags:
+        - project
+      summary: Add a new document to the project.
+      operationId: createDocument
+      parameters:
+        - name: projectID
+          in: path
+          required: true
+          description: The ID of the project to add a document to.
+          schema:
+            type: string
+      requestBody:
+        description: Currently unused, as long as it's not a form.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: |
+            The newly created document.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+
   /app/projects/{projectID}/diagrams/{documentID}/version/{version}:
     get:
       tags:

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Compile an ESM version of this codebase for Node.JS v18.
 - Add `MermaidChart#getDiagram(diagramID)` function to get a diagram.
+- Add `MermaidChart#createDocument(projectID)` function to create a digram in a project.
 
 ### Fixed
 

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -7,6 +7,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import process from 'node:process';
 import { AxiosError } from 'axios';
 
+// hard-coded, replace with your own project,
+// or ask alois is you want this to be shared with your account
+const testProjectId = '316557b3-cb6f-47ed-acf7-fcfb7ce188d5';
+
 let client: MermaidChart;
 
 beforeAll(async() => {
@@ -38,6 +42,21 @@ const documentMatcher = expect.objectContaining({
   documentID: expect.any(String),
   major: expect.any(Number),
   minor: expect.any(Number),
+});
+
+describe('createDocument', () => {
+  it('should create document in project', async() => {
+    const existingDocuments = await client.getDocuments(testProjectId);
+
+    const newDocument = await client.createDocument(testProjectId);
+
+    expect(newDocument).toStrictEqual(documentMatcher);
+
+    const updatedProjectDocuments = await client.getDocuments(testProjectId);
+
+    expect(existingDocuments).not.toContainEqual(newDocument);
+    expect(updatedProjectDocuments).toContainEqual(newDocument);
+  });
 });
 
 describe("getDocument", () => {
@@ -73,3 +92,4 @@ describe("getDocument", () => {
     expect(error?.response?.status).toBe(404);
   });
 });
+

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -173,6 +173,14 @@ export class MermaidChart {
     return projects.data;
   }
 
+  public async createDocument(projectID: string) {
+    const newDocument = await this.axios.post<MCDocument>(
+      URLS.rest.projects.get(projectID).documents,
+      {}, // force sending empty JSON to avoid triggering CSRF check
+    );
+    return newDocument.data;
+  }
+
   public async getEditURL(
     document: Pick<MCDocument, 'documentID' | 'major' | 'minor' | 'projectID'>,
   ) {


### PR DESCRIPTION
This function creates a new document in the given project. Due to a CSRF issue that forbids us from sending FormData, we have to send an empty JSON object in the body to force Axios **not** to send FormData.

![image](https://github.com/Mermaid-Chart/plugins/assets/19716675/51f146f9-d8bd-4c75-af4f-d0c2ddb8dbc4)
