### PR TITLE
feat: add `deleteDocument(documentID)` API func

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -48,23 +48,45 @@ components:
         - title
     Document:
       type: object
+      description: |
+        MermaidChart document that may contain a diagram.
       properties:
-        documentID:
-          type: string
         projectID:
           type: string
-        major:
-          type: integer
-        minor:
-          type: integer
         title:
           type: string
       required:
         - documentID
         - projectID
-        - major
-        - minor
         - title
+    DiagramDocument:
+      type: object
+      description: |
+        MermaidChart diagram document, without any Document metadata.
+      properties:
+        documentID:
+          description: |
+            The id of the document that this diagram is linked to.
+          type: string
+          format: uuid
+        major:
+          type: integer
+        minor:
+          type: integer
+        id:
+          type: string
+          format: uuid
+          description: |
+            The id of this diagram, required for `setDocument()`.
+      required:
+        - documentID
+        - id
+    MCDocument:
+      description: |
+        MermaidChart diagram document.
+      allOf:
+        - $ref: "#/components/schemas/Document"
+        - $ref: "#/components/schemas/DiagramDocument"
 
   securitySchemes:
     bearer_auth:
@@ -127,7 +149,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Document'
+                  $ref: '#/components/schemas/MCDocument'
     post:
       tags:
         - project
@@ -150,11 +172,11 @@ paths:
       responses:
         '200':
           description: |
-            The newly created document.
+            The newly created diagram document.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Document'
+                $ref: '#/components/schemas/MCDocument'
 
   /app/projects/{projectID}/diagrams/{documentID}/version/{version}:
     get:
@@ -187,7 +209,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Document'
+                $ref: '#/components/schemas/MCDocument'
 
   /rest-api/documents/{documentID}:
     get:
@@ -221,7 +243,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Document'
+                $ref: '#/components/schemas/MCDocument'
         '404':
           description: File Not Found
     delete:
@@ -240,8 +262,12 @@ paths:
         - mermaidchart_auth: []
       responses:
         '200':
-          description: Metadata about the deleted document.
-          # TODO: update the sever to actually return the full document.
+          description: The deleted document.
+          content:
+            application/json:
+              schema:
+                # currently only returns the document, no diagram data!!!!
+                $ref: '#/components/schemas/Document'
 
   /raw/{documentID}:
     get:

--- a/openapi.yml
+++ b/openapi.yml
@@ -224,6 +224,24 @@ paths:
                 $ref: '#/components/schemas/Document'
         '404':
           description: File Not Found
+    delete:
+      tags:
+        - document
+      summary: Delete the given document.
+      operationId: deleteDocument
+      parameters:
+        - name: documentID
+          in: path
+          required: true
+          description: The ID of the document to delete.
+          schema:
+            type: string
+      security:
+        - mermaidchart_auth: []
+      responses:
+        '200':
+          description: Metadata about the deleted document.
+          # TODO: update the sever to actually return the full document.
 
   /raw/{documentID}:
     get:

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compile an ESM version of this codebase for Node.JS v18.
 - Add `MermaidChart#getDiagram(diagramID)` function to get a diagram.
 - Add `MermaidChart#createDocument(projectID)` function to create a digram in a project.
+- Add `MermaidChart#deleteDocument(documentID)` function to delete a diagram.
 
 ### Fixed
 

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -59,6 +59,20 @@ describe('createDocument', () => {
   });
 });
 
+describe('deleteDocument', () => {
+  it('should delete document', async() => {
+    const newDocument = await client.createDocument(testProjectId);
+
+    expect(await client.getDocuments(testProjectId)).toContainEqual(newDocument);
+
+    const deletedDoc = await client.deleteDocument(newDocument.documentID);
+
+    expect(deletedDoc.projectID).toStrictEqual(newDocument.projectID);
+
+    expect(await client.getDocuments(testProjectId)).not.toContainEqual(newDocument);
+  });
+});
+
 describe("getDocument", () => {
   it("should get publicly shared diagram", async() => {
     const latestDocument = await client.getDocument({

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -2,10 +2,11 @@
  * E2E tests
  */
 import { MermaidChart } from './index.js';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import process from 'node:process';
 import { AxiosError } from 'axios';
+import { MCDocument } from './types.js';
 
 // hard-coded, replace with your own project,
 // or ask alois is you want this to be shared with your account
@@ -44,11 +45,25 @@ const documentMatcher = expect.objectContaining({
   minor: expect.any(Number),
 });
 
+/**
+ * Cleanup created documents at the end of this test.
+ */
+const documentsToDelete = new Set<MCDocument["documentID"]>();
+afterAll(async() => {
+  await Promise.all(Array.from(documentsToDelete).map(async(document) => {
+    if (documentsToDelete.delete(document)) {
+      await client.deleteDocument(document);
+    }
+  }));
+});
+
 describe('createDocument', () => {
   it('should create document in project', async() => {
     const existingDocuments = await client.getDocuments(testProjectId);
 
     const newDocument = await client.createDocument(testProjectId);
+
+    documentsToDelete.add(newDocument.documentID);
 
     expect(newDocument).toStrictEqual(documentMatcher);
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,7 @@ import { RequiredParameterMissingError, OAuthError } from './errors.js';
 import { URLS } from './urls.js';
 import type {
   AuthState,
+  Document,
   InitParams,
   AuthorizationData,
   MCUser,
@@ -201,7 +202,7 @@ export class MermaidChart {
    * @returns Metadata about the deleted document.
    */
   public async deleteDocument(documentID: MCDocument['documentID']) {
-    const deletedDocument = await this.axios.delete<Pick<MCDocument, 'projectID' | 'title'>>(
+    const deletedDocument = await this.axios.delete<Document>(
       URLS.rest.documents.pick({documentID}).self,
       {}, // force sending empty JSON to avoid triggering CSRF check
     );

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -195,6 +195,19 @@ export class MermaidChart {
     return data;
   }
 
+  /**
+   * Delete the given document.
+   * @param documentID The ID of the document to delete.
+   * @returns Metadata about the deleted document.
+   */
+  public async deleteDocument(documentID: MCDocument['documentID']) {
+    const deletedDocument = await this.axios.delete<Pick<MCDocument, 'projectID' | 'title'>>(
+      URLS.rest.documents.pick({documentID}).self,
+      {}, // force sending empty JSON to avoid triggering CSRF check
+    );
+    return deletedDocument.data;
+  }
+
   public async getRawDocument(
     document: Pick<MCDocument, 'documentID' | 'major' | 'minor'>,
     theme: 'light' | 'dark',

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -28,12 +28,29 @@ export interface MCProject {
   title: string;
 }
 
-export interface MCDocument {
-  documentID: string;
+/**
+ * MermaidChart diagram document.
+ */
+export type MCDocument = Document & DiagramDocument;
+
+/**
+ * MermaidChart document that may contain a diagram.
+ */
+export interface Document {
   projectID: string;
+  title: string;
+}
+
+/**
+ * MermaidChart diagram document, without any {@link Document} metadata.
+ */
+export interface DiagramDocument {
+  /** The id of this diagram, required for `setDocument()` */
+  id: string;
+  /** The id of the document that this diagram is linked to. */
+  documentID: string;
   major: number;
   minor: number;
-  title: string;
 }
 
 export interface AuthorizationData {


### PR DESCRIPTION
**Draft PR: This PR is stacked on top of:**
  - #9.

**Please change this PR to target `main` once #9 has been merged.**

Adds the API function for deleting a document. Unlike most other API functions, this function doesn't return an `MCDocument`, just a plain `Document` without any diagram information.

I've mainly added this function to help with cleaning up E2E tests, since otherwise we'll make millions of diagrams that will fill up our database/projects!

![image](https://github.com/Mermaid-Chart/plugins/assets/19716675/a715864d-08d8-4e9b-be88-e0cb7d304f69)
