### PR TITLE
ci(build): run GitHub Actions on MacOS and Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,9 @@ jobs:
       matrix:
         node: ['18.18.x']
         pkg: ['sdk', 'cli']
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on:
-      labels: ubuntu-latest
+      labels: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 📖 Description

Run the `test` GitHub Actions job on Windows, macOS, and Ubuntu.

Although I haven't detected an OS specific bug in the `main` branch, this did help me find and debug a Windows specific bug in my #12 PR, see https://github.com/Mermaid-Chart/plugins/pull/12/commits/f234f3ec22e98c1d7f8ef712769fc3a648c92bea.

### Potential issues

From [About billing for GitHub Actions # Per-minute rates](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers):

- Windows CI is twice the price of Ubuntu CI.
- MacOS CI is ten times the price of Ubuntu CI!!!

However, **GitHub Actions usage is free for standard GitHub-hosted runners in public repositories**, and since this repo is public, it's free for us! If GitHub Actions ever changes their pricing so that CI is no longer free, we can always disable this change in the future.