### PR TITLE
feat(cli): support `pull`/`push`/`link` on multiple mermaid files at once

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.1.0",
     "@iarna/toml": "^2.2.5",
+    "@inquirer/confirm": "^2.0.15",
     "@inquirer/input": "^1.2.14",
     "@inquirer/select": "^1.3.1",
     "@mermaidchart/sdk": "workspace:^",

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -218,9 +218,13 @@ describe('link', () => {
 
 describe('pull', () => {
   const diagram = 'test/output/connected-diagram.mmd';
+  const diagram2 = 'test/output/connected-diagram-2.mmd';
 
   beforeEach(async () => {
-    await copyFile('test/fixtures/connected-diagram.mmd', diagram);
+    await Promise.all([
+      copyFile('test/fixtures/connected-diagram.mmd', diagram),
+      copyFile('test/fixtures/connected-diagram.mmd', diagram2),
+    ]);
   });
 
   it('should fail if MermaidChart document has not yet been linked', async () => {
@@ -243,7 +247,7 @@ describe('pull', () => {
     ).rejects.toThrowError(`Diagram at ${diagram} has no code`);
   });
 
-  it('should pull document and add a `id:` field to frontmatter', async () => {
+  it('should pull documents and add a `id:` field to frontmatter', async () => {
     const { program } = mockedProgram();
 
     const mockedDiagram = {
@@ -255,22 +259,30 @@ title: My cool flowchart
       A[I've been updated!]`,
     };
 
-    vi.mocked(MermaidChart.prototype.getDocument).mockResolvedValueOnce(mockedDiagram);
+    vi.mocked(MermaidChart.prototype.getDocument).mockResolvedValue(mockedDiagram);
 
-    await program.parseAsync(['--config', CONFIG_AUTHED, 'pull', diagram], { from: 'user' });
+    await program.parseAsync(['--config', CONFIG_AUTHED, 'pull', diagram, diagram2], {
+      from: 'user',
+    });
 
-    const diagramContents = await readFile(diagram, { encoding: 'utf8' });
+    for (const file of [diagram, diagram2]) {
+      const diagramContents = await readFile(file, { encoding: 'utf8' });
 
-    expect(diagramContents).toContain(`id: ${mockedDiagram.documentID}`);
-    expect(diagramContents).toContain("flowchart TD\n      A[I've been updated!]");
+      expect(diagramContents).toContain(`id: ${mockedDiagram.documentID}`);
+      expect(diagramContents).toContain("flowchart TD\n      A[I've been updated!]");
+    }
   });
 });
 
 describe('push', () => {
   const diagram = 'test/output/connected-diagram.mmd';
+  const diagram2 = 'test/output/connected-diagram-2.mmd';
 
   beforeEach(async () => {
-    await copyFile('test/fixtures/connected-diagram.mmd', diagram);
+    await Promise.all([
+      copyFile('test/fixtures/connected-diagram.mmd', diagram),
+      copyFile('test/fixtures/connected-diagram.mmd', diagram2),
+    ]);
   });
 
   it('should fail if MermaidChart document has not yet been linked', async () => {
@@ -283,16 +295,18 @@ describe('push', () => {
     ).rejects.toThrowError('Diagram at test/fixtures/unsynced.mmd has no id');
   });
 
-  it('should push document and remove the `id:` field front frontmatter', async () => {
+  it('should push documents and remove the `id:` field front frontmatter', async () => {
     const { program } = mockedProgram();
 
-    vi.mocked(MermaidChart.prototype.getDocument).mockResolvedValueOnce(mockedEmptyDiagram);
+    vi.mocked(MermaidChart.prototype.getDocument).mockResolvedValue(mockedEmptyDiagram);
 
     await expect(readFile(diagram, { encoding: 'utf8' })).resolves.not.toContain(/^id:/);
 
-    await program.parseAsync(['--config', CONFIG_AUTHED, 'push', diagram], { from: 'user' });
+    await program.parseAsync(['--config', CONFIG_AUTHED, 'push', diagram, diagram2], {
+      from: 'user',
+    });
 
-    expect(vi.mocked(MermaidChart.prototype.setDocument)).toHaveBeenCalledOnce();
+    expect(vi.mocked(MermaidChart.prototype.setDocument)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(MermaidChart.prototype.setDocument)).toHaveBeenCalledWith(
       expect.objectContaining({
         code: expect.not.stringContaining('id:'),

--- a/packages/cli/src/commander.ts
+++ b/packages/cli/src/commander.ts
@@ -167,37 +167,37 @@ function linkCmd() {
 
       // Ask the user which project they want to upload each diagram to
       const getProjectId: LinkOptions['getProjectId'] = async (cache, documentTitle) => {
-            if (cache.previousSelectedProjectId !== undefined) {
-              if (cache.usePreviousSelectedProjectId === undefined) {
-                cache.usePreviousSelectedProjectId = confirm({
-                  message: `Would you like to upload all diagrams to this project?`,
-                  default: true,
-                });
-              }
-              if (await cache.usePreviousSelectedProjectId) {
-                return cache.previousSelectedProjectId;
-              }
-            }
-
-            cache.projects = cache.projects ?? client.getProjects();
-            const projectId = await select({
-              message: `Select a project to upload ${documentTitle} to`,
-              choices: [
-                ...(await cache.projects).map((project) => {
-                  return {
-                    name: project.title,
-                    value: project.id,
-                  };
-                }),
-                new Separator(
-                  `Or go to ${new URL('/app/projects', client.baseURL)} to create a new project`,
-                ),
-              ],
+        if (cache.previousSelectedProjectId !== undefined) {
+          if (cache.usePreviousSelectedProjectId === undefined) {
+            cache.usePreviousSelectedProjectId = confirm({
+              message: `Would you like to upload all diagrams to this project?`,
+              default: true,
             });
+          }
+          if (await cache.usePreviousSelectedProjectId) {
+            return cache.previousSelectedProjectId;
+          }
+        }
 
-            cache.previousSelectedProjectId = projectId;
+        cache.projects = cache.projects ?? client.getProjects();
+        const projectId = await select({
+          message: `Select a project to upload ${documentTitle} to`,
+          choices: [
+            ...(await cache.projects).map((project) => {
+              return {
+                name: project.title,
+                value: project.id,
+              };
+            }),
+            new Separator(
+              `Or go to ${new URL('/app/projects', client.baseURL)} to create a new project`,
+            ),
+          ],
+        });
 
-            return projectId;
+        cache.previousSelectedProjectId = projectId;
+
+        return projectId;
       };
 
       const linkCache = {};

--- a/packages/cli/src/commander.ts
+++ b/packages/cli/src/commander.ts
@@ -196,40 +196,48 @@ function linkCmd() {
 
 function pullCmd() {
   return createCommand('pull')
-    .description('Pulls a document from from Mermaid Chart')
-    .addArgument(new Argument('<path>', 'The path of the file to pull.'))
-    .option('--check', 'Check whether the local file would be overwrited')
-    .action(async (path, options, command) => {
+    .description('Pulls documents from Mermaid Chart')
+    .addArgument(new Argument('<path...>', 'The paths of the files to pull.'))
+    .option('--check', 'Check whether the local files would be overwrited')
+    .action(async (paths, options, command) => {
       const optsWithGlobals = command.optsWithGlobals<CommonOptions>();
       const client = await createClient(optsWithGlobals);
-      const text = await readFile(path, { encoding: 'utf8' });
+      await Promise.all(
+        paths.map(async (path) => {
+          const text = await readFile(path, { encoding: 'utf8' });
 
-      const newFile = await pull(text, client, { title: path });
+          const newFile = await pull(text, client, { title: path });
 
-      if (text === newFile) {
-        console.log(`✅ - ${path} is up to date`);
-      } else {
-        if (options['check']) {
-          console.log(`❌ - ${path} would be updated`);
-          process.exitCode = 1;
-        } else {
-          await writeFile(path, newFile, { encoding: 'utf8' });
-          console.log(`✅ - ${path} was updated`);
-        }
-      }
+          if (text === newFile) {
+            console.log(`✅ - ${path} is up to date`);
+          } else {
+            if (options['check']) {
+              console.log(`❌ - ${path} would be updated`);
+              process.exitCode = 1;
+            } else {
+              await writeFile(path, newFile, { encoding: 'utf8' });
+              console.log(`✅ - ${path} was updated`);
+            }
+          }
+        }),
+      );
     });
 }
 
 function pushCmd() {
   return createCommand('push')
-    .description('Push a local diagram to Mermaid Chart')
-    .addArgument(new Argument('<path>', 'The path of the file to push.'))
-    .action(async (path, _options, command) => {
+    .description('Push local diagrams to Mermaid Chart')
+    .addArgument(new Argument('<path...>', 'The paths of the files to push.'))
+    .action(async (paths, _options, command) => {
       const optsWithGlobals = command.optsWithGlobals<CommonOptions>();
       const client = await createClient(optsWithGlobals);
-      const text = await readFile(path, { encoding: 'utf8' });
+      await Promise.all(
+        paths.map(async (path) => {
+          const text = await readFile(path, { encoding: 'utf8' });
 
-      await push(text, client, { title: path });
+          await push(text, client, { title: path });
+        }),
+      );
     });
 }
 

--- a/packages/cli/src/methods.ts
+++ b/packages/cli/src/methods.ts
@@ -33,7 +33,10 @@ interface CommonOptions {
   title: string;
 }
 
-interface LinkOptions extends CommonOptions {
+/**
+ * Options to pass to {@link link}.
+ */
+export interface LinkOptions extends CommonOptions {
   /** Function that asks the user which project id they want to upload a diagram to */
   getProjectId: (cache: LinkOptions['cache'], documentTitle: string) => Promise<string>;
   // cache to be shared between link calls. This object may be modified between calls.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@inquirer/confirm':
+        specifier: ^2.0.15
+        version: 2.0.15
       '@inquirer/input':
         specifier: ^1.2.14
         version: 1.2.14
@@ -361,7 +364,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: ^4.3.7
-        version: 4.3.7(@types/node@18.18.12)
+        version: 4.3.7(@types/node@20.8.5)
       vitest:
         specifier: ^0.30.1
         version: 0.30.1(jsdom@21.0.0)
@@ -3464,6 +3467,15 @@ packages:
       svelte: 3.59.1
     dev: false
 
+  /@inquirer/confirm@2.0.15:
+    resolution: {integrity: sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==}
+    engines: {node: '>=14.18.0'}
+    dependencies:
+      '@inquirer/core': 5.1.1
+      '@inquirer/type': 1.1.5
+      chalk: 4.1.2
+    dev: false
+
   /@inquirer/core@5.1.1:
     resolution: {integrity: sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==}
     engines: {node: '>=14.18.0'}
@@ -4149,7 +4161,7 @@ packages:
       svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.1
-      vite: 4.3.7(@types/node@18.18.12)
+      vite: 4.3.7(@types/node@20.8.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -4164,7 +4176,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 2.4.5(svelte@3.59.1)(vite@4.3.7)
       debug: 4.3.4
       svelte: 3.59.1
-      vite: 4.3.7(@types/node@18.18.12)
+      vite: 4.3.7(@types/node@20.8.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -4182,7 +4194,7 @@ packages:
       magic-string: 0.30.3
       svelte: 3.59.1
       svelte-hmr: 0.15.3(svelte@3.59.1)
-      vite: 4.3.7(@types/node@18.18.12)
+      vite: 4.3.7(@types/node@20.8.5)
       vitefu: 0.2.4(vite@4.3.7)
     transitivePeerDependencies:
       - supports-color
@@ -4348,7 +4360,6 @@ packages:
     resolution: {integrity: sha512-SPlobFgbidfIeOYlzXiEjSYeIJiOCthv+9tSQVpvk4PAdIIc+2SmjNVzWXk9t0Y7dl73Zdf+OgXKHX9XtkqUpw==}
     dependencies:
       undici-types: 5.25.3
-    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -13525,7 +13536,6 @@ packages:
 
   /undici-types@5.25.3:
     resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
-    dev: true
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -13836,6 +13846,7 @@ packages:
       rollup: 3.26.3
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /vite@4.3.7(@types/node@20.8.5):
     resolution: {integrity: sha512-MTIFpbIm9v7Hh5b0wSBgkcWzSBz7SAa6K/cBTwS4kUiQJfQLFlZZRJRQgqunCVzhTPCk674tW+0Qaqh3Q00dBg==}
@@ -13868,7 +13879,6 @@ packages:
       rollup: 3.26.3
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.4(vite@4.3.7):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
@@ -13878,7 +13888,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.7(@types/node@18.18.12)
+      vite: 4.3.7(@types/node@20.8.5)
 
   /vitest@0.30.1(jsdom@21.0.0):
     resolution: {integrity: sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==}


### PR DESCRIPTION
**Draft PR: This PR is stacked on top of:**
  - #12, which is stacked on top of
  - #11, which is stacked on top of
  - #10, which is stacked on top of
  - #9.

**Please change this PR to target `main` once #12 has been merged.**

## 📖 Description

Currently, the `mermaid-chart` CLI can only `pull`/`push`/`link` a single file at a time. 

This PR adds support for pulling/pushing/linking multiple files at once with the `@mermaidchart/cli` CLI, e.g. like `mermaid-chart pull file1 file2`.

If using `bash`, this means you can run commands like `npx mermaid-chart pull docs/*.mmd`, as your shell will automatically expand `docs/*.mmd`.

```console
me@pc:~$ npx mermaid-chart --help
Usage: mermaid-cli [options] [command]

CLI for interacting with https://MermaidChart.com, the platform that makes collaborating with Mermaid diagrams easy.

Options:
  -V, --version               output the version number
  -c, --config <config_file>  The path to the config file to use. (default: "/home/alois/.config/mermaid-chart.toml")
  -h, --help                  display help for command

Commands:
  whoami                      Display Mermaid Chart username
  login                       Login to a Mermaid Chart account
  logout                      Log out of a Mermaid Chart account
  link <path...>              Link the given Mermaid diagrams to Mermaid Chart
  pull [options] <path...>    Pulls documents from Mermaid Chart
  push <path...>              Push local diagrams to Mermaid Chart
  help [command]              display help for command
```

### `link`-ing multiple files

When running `mermaid-chart link diagram1.mmd diagram2.mmd diagram3.mmd`, the mermaid-chart CLI will ask the user if they want to upload all the diagrams to the same project. If not, then the CLI will ask the user for the project for each diagram:

```console
me@pc:~/MermaidChart/plugins/packages/cli (feat/support-multiple-files-at-once-in-cli)$ npx ts-node@^11.0.0-beta.1 --esm ./src/cli.ts link test/output/unsynced*.mmd
? Select a project to upload test/output/unsynced1.mmd to tmp
? Would you like to upload all diagrams to this project? no
? Select a project to upload test/output/unsynced2.mmd to tmp
? Select a project to upload test/output/unsynced3.mmd to tmp
? Select a project to upload test/output/unsynced.mmd to
  personal
  GitHub Actions test project
❯ tmp
```

### `push`/`pull`-ing multiple files

When pulling/pushing multiple files, the CLI will print some info about each file:

```console
me@pc:~/MermaidChart/plugins/packages/cli (feat/support-multiple-files-at-once-in-cli)$ npx ts-node@^11.0.0-beta.1 --esm ./src/cli.ts push test/output/unsynced*.mmd
✅ - test/output/unsynced3.mmd is up to date
✅ - test/output/unsynced2.mmd is up to date
✅ - test/output/unsynced1.mmd is up to date
me@pc:~/MermaidChart/plugins/packages/cli (feat/support-multiple-files-at-once-in-cli)$ npx ts-node@^11.0.0-beta.1 --esm ./src/cli.ts pull test/output/unsynced*.mmd
✅ - test/output/unsynced1.mmd is up to date
✅ - test/output/unsynced2.mmd was updated
✅ - test/output/unsynced3.mmd is up to date
```