### PR TITLE
fix(sdk): fix the required params of the `setDocument()` command

### DIFF
--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -85,6 +85,7 @@ describe('setDocument', () => {
     await client.setDocument({
       documentID: newDocument.documentID,
       id: newDocument.id, // diagram ID
+      projectID: newDocument.projectID,
       title: "@mermaidchart/sdk E2E test diagram",
       code,
     });

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -98,8 +98,7 @@ describe('setDocument', () => {
     });
   });
 
-  // TODO: this function never seems to return an error, see MC-1060
-  it.skip('should throw an error on invalid data', async() => {
+  it('should throw an error on invalid data', async() => {
     const newDocument = await client.createDocument(testProjectId);
     documentsToDelete.add(newDocument.documentID);
 

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -84,7 +84,6 @@ describe('setDocument', () => {
 
     await client.setDocument({
       documentID: newDocument.documentID,
-      id: newDocument.id, // diagram ID
       projectID: newDocument.projectID,
       title: "@mermaidchart/sdk E2E test diagram",
       code,
@@ -106,8 +105,8 @@ describe('setDocument', () => {
 
     await expect(client.setDocument({
       documentID: newDocument.documentID,
-      // @ts-expect-error not setting diagram `id` should throw an error
-      id: null,
+      // @ts-expect-error not setting diagram `projectID` should throw an error
+      projectID: null,
     })).rejects.toThrowError("400"); // should throw HTTP 400 error
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -210,7 +210,7 @@ export class MermaidChart {
    * @param document The document to update.
    */
   public async setDocument(
-    document: Pick<MCDocument, 'id' | 'documentID' | 'projectID'> & Partial<MCDocument>,
+    document: Pick<MCDocument, 'documentID' | 'projectID'> & Partial<MCDocument>,
   ) {
     const {data} = await this.axios.put<{result: "ok"} | {result: "failed", error: any}>(
       URLS.rest.documents.pick(document).self,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -210,7 +210,7 @@ export class MermaidChart {
    * @param document The document to update.
    */
   public async setDocument(
-    document: Pick<MCDocument, 'id' | 'documentID'> & Partial<MCDocument>,
+    document: Pick<MCDocument, 'id' | 'documentID' | 'projectID'> & Partial<MCDocument>,
   ) {
     const {data} = await this.axios.put<{result: "ok"} | {result: "failed", error: any}>(
       URLS.rest.documents.pick(document).self,


### PR DESCRIPTION
The `setDocument()` (aka `PUT /rest-api/documents/{documentID}`) command in the REST API now doesn't need an `id` param, but it does need a `projectID` parameter.

Since `setDocument()` hasn't yet been released to NPM, we don't need to yet update the CHANGELOG.md file.

This fixes the E2E tests that were failing in this repo (e.g. https://github.com/Mermaid-Chart/plugins/actions/runs/7952846469/job/22299559265).