### PR TITLE
test(sdk): make e2e tests more configurable

### DIFF
--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -155,17 +155,20 @@ describe('deleteDocument', () => {
 });
 
 describe("getDocument", () => {
-  it("should get publicly shared diagram", async() => {
+  it("should get diagram", async() => {
+    const newDocument = await client.createDocument(testProjectId);
+
+    documentsToDelete.add(newDocument.documentID);
+
     const latestDocument = await client.getDocument({
-      // owned by alois@mermaidchart.com
-      documentID: '8bce727b-69b7-4f6e-a434-d578e2b363ff',
+      documentID: newDocument.documentID,
+      // major and minor are optional
     });
 
     expect(latestDocument).toStrictEqual(documentMatcher);
 
     const earliestDocument = await client.getDocument({
-      // owned by alois@mermaidchart.com
-      documentID: '8bce727b-69b7-4f6e-a434-d578e2b363ff',
+      documentID: newDocument.documentID,
       major: 0,
       minor: 1,
     });


### PR DESCRIPTION
Currently, the `@mermaidchart/sdk` E2E tests are hard-coded to only test a single server and a single user account.

This PR modifies the E2E tests to load some test config variables from the `TEST_MERMAIDCHART_BASE_URL` and
`TEST_MERMAIDCHART_PROJECT_ID` environment variables, so that different mermaidchart accounts and servers can be used.