### PR TITLE
feat(cli): support reading auth token in CLI with `--auth-token` and in ENV with `MERMAID_CHART_AUTH_TOKEN`

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -5,6 +5,7 @@
     "Cataa",
     "colour",
     "Cookiebot",
+    "ENONET",
     "gantt",
     "jsnext",
     "lintstagedrc",

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -189,7 +189,9 @@ describe('logout', () => {
 
     await expect(readFile(configFile, { encoding: 'utf8' })).resolves.not.toContain('my-api-key');
 
-    expect(consoleLogSpy).toBeCalledWith(`API token removed from ${configFile}`);
+    expect(consoleLogSpy).toBeCalledWith(
+      `API token for ${mockedMCUser.emailAddress} removed from ${configFile}`,
+    );
   });
 });
 

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -136,6 +136,19 @@ describe('whoami', () => {
     ).rejects.toThrowError('Invalid access token.');
   });
 
+  it('--auth-token should override config file', async () => {
+    const { program } = mockedProgram();
+
+    const myCliAuthToken = 'my-cli-auth-token';
+
+    await program.parseAsync(
+      ['--config', CONFIG_AUTHED, '--auth-token', myCliAuthToken, 'whoami'],
+      { from: 'user' },
+    );
+
+    expect(vi.mocked(MermaidChart.prototype.setAccessToken)).toHaveBeenCalledWith(myCliAuthToken);
+  });
+
   it('should print email of logged in user', async () => {
     const { program } = mockedProgram();
 

--- a/packages/cli/src/commander.ts
+++ b/packages/cli/src/commander.ts
@@ -296,12 +296,15 @@ export function createCommanderCommand() {
       defaultConfigPath(),
     )
     .addOption(
-      new Option(
-        '--base-url <base_url>',
-        'The base URL of the Mermaid Chart instance to use.',
-      ).default('https://mermaidchart.com'),
+      new Option('--base-url <base_url>', 'The base URL of the Mermaid Chart instance to use.')
+        .default('https://mermaidchart.com')
+        .env('MERMAID_CHART_BASE_URL'),
     )
-    .addOption(new Option('--auth-token <auth_token>', 'The Mermaid Chart API token to use.'))
+    .addOption(
+      new Option('--auth-token <auth_token>', 'The Mermaid Chart API token to use.').env(
+        'MERMAID_CHART_AUTH_TOKEN',
+      ),
+    )
     .hook('preSubcommand', async (command, actionCommand) => {
       const configPath = command.getOptionValue('config');
       /**

--- a/packages/cli/src/commander.ts
+++ b/packages/cli/src/commander.ts
@@ -37,10 +37,11 @@ async function createClient(options: CommonOptions, config?: Config) {
         options['config'] === defaultConfigPath()
       ) {
         config = {};
+      } else {
+        throw new InvalidArgumentError(
+          `Failed to load config file ${options['config']} due to: ${error}`,
+        );
       }
-      throw new InvalidArgumentError(
-        `Failed to load config file ${options['config']} due to: ${error}`,
-      );
     }
   }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -38,6 +38,19 @@ export function defaultConfigPath() {
   return join(userConfigDir(), 'mermaid-chart.toml');
 }
 
+/**
+ * Maps the TOML keys to the Commander option names.
+ *
+ * Commander uses:
+ *   - kebab-case for CLI options, but
+ *   - camelCase for option names in JavaScript,
+ * while TOML uses snake_case.
+ */
+export const optionNameMap = {
+  auth_token: 'authToken',
+  base_url: 'baseUrl',
+} as const;
+
 export interface Config extends JsonMap {
   /**
    * Mermaid-Chart API token.


### PR DESCRIPTION
> [!Note]
>
> This PR is stacked on top of:
>  - #20, which is stacked on top of
>  - #16, which is stacked on top of
>  - #15, which is stacked on top of
>  - #12

Support loading the auth token and Mermaid Chart base URL from environment variables using `MERMAID_CHART_AUTH_TOKEN` and `MERMAID_CHART_BASE_URL`, and from the CLI using `--auth-token <authToken>` and `--base-url <baseUrl>`.

The order of priority is:
  1. CLI `--options`
  2. Environment variables
  3. Config file
  4. Default values

This is to make it easier for us to use the `@mermaidchart/cli` in CI providers, like in a GitHub Action workflow.

### Notes to reviewers

I've used Commander.js to handle setting these variables, so run `npx @mermaidchart/cli` automatically prints documentation for this:

```console
alois@pc:~/plugins/packages/cli (feat/support-loading-tokens-from-environment-variables)$ npx tsx src/cli.ts --help
Usage: mermaid-cli [options] [command]

CLI for interacting with https://MermaidChart.com, the platform that makes collaborating with Mermaid diagrams easy.

Options:
  -V, --version               output the version number
  -c, --config <config_file>  The path to the config file to use. (default: "/home/alois/.config/mermaid-chart.toml")
  --base-url <base_url>       The base URL of the Mermaid Chart instance to use. (default: "https://mermaidchart.com", env: MERMAID_CHART_BASE_URL)
  --auth-token <auth_token>   The Mermaid Chart API token to use. (env: MERMAID_CHART_AUTH_TOKEN)
  -h, --help                  display help for command

<---TRUNCATED TO MAKE THIS PR SMALLER -->
```

Also, I know this is a bit of a big PR, so it might be easier to review it commit-by-commit!
