### PR TITLE
chore(sdk): publish @mermaidchart/sdk v0.2.0

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -5,24 +5,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-04-11
+
 ### Added
 
 - Compile an ESM version of this codebase for Node.JS v18.
 - Add `MermaidChart#getDiagram(diagramID)` function to get a diagram.
-- Add `MermaidChart#createDocument(projectID)` function to create a digram in a project.
+- Add `MermaidChart#createDocument(projectID)` function to create a diagram in a project.
 - Add `MermaidChart#setDocument(document)` function to update a diagram.
 - Add `MermaidChart#deleteDocument(documentID)` function to delete a diagram.
 
 ### Fixed
 
-- Fix `MCDocument` `major`/`minor` type to `number`.
-- Add `code` field to `MCDocument` type
-
-### Fixed
-
+- **BREAKING:** Fix `MCDocument` `major`/`minor` type to `number`.
+- Add `code` field to `MCDocument` type.
 - `MermaidChart#getAuthorizationData()` now correctly sets `state` in the URL
   by default.
 - `MermaidChart#handleAuthorizationResponse()` now supports relative URLs.
 
 ## [0.1.1] - 2023-09-08
+
 - Browser-only build.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mermaidchart/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Access the MermaidChart services with OAuth and type safety.",
   "browser": "dist/bundle.iife.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.2.0 of the `@mermaidchart/sdk`.

### CHANGELOG

#### Added

- Compile an ESM version of this codebase for Node.JS v18.
- Add `MermaidChart#getDiagram(diagramID)` function to get a diagram.
- Add `MermaidChart#createDocument(projectID)` function to create a diagram in a project.
- Add `MermaidChart#setDocument(document)` function to update a diagram.
- Add `MermaidChart#deleteDocument(documentID)` function to delete a diagram.

#### Fixed

- **BREAKING**: Fix `MCDocument` `major`/`minor` type to `number`.
- Add `code` field to `MCDocument` type.
- `MermaidChart#getAuthorizationData()` now correctly sets `state` in the URL by default.
- `MermaidChart#handleAuthorizationResponse()` now supports relative URLs.

---

E2E tests are failing since my account on https://test.mermaidchart.com is only a free account, and due to Stripe issues, I can't upgrade it to a paid account.