### PR TITLE
chore(cli): publish @mermaidchart/cli v0.1.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2024-04-22
+
+Initial release.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,13 +1,11 @@
 {
   "name": "@mermaidchart/cli",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0",
   "description": "CLI for interacting with https://MermaidChart.com, the platform that makes collaborating with Mermaid diagrams easy",
   "main": "index.js",
   "bin": {
     "mermaid-chart": "dist/cli.js"
   },
-  "//1": "temporarily disable pushing until we finish progress on this",
-  "private": true,
   "engines": {
     "node": "^18.18.0 || ^20.0.0"
   },
@@ -57,7 +55,7 @@
     "@inquirer/confirm": "^2.0.15",
     "@inquirer/input": "^1.2.14",
     "@inquirer/select": "^1.3.1",
-    "@mermaidchart/sdk": "workspace:^",
+    "@mermaidchart/sdk": "^0.2.1-alpha.0",
     "commander": "^11.1.0",
     "remark": "^15.0.1",
     "remark-frontmatter": "^5.0.0",

--- a/packages/cli/src/remark.ts
+++ b/packages/cli/src/remark.ts
@@ -53,7 +53,7 @@ export function plugin({ client, ...options }: MCPluginOptions) {
         case 'link':
           node.value = await link(node.value, client, {
             cache: options.cache,
-            title: ``,
+            title, // TODO: should we update this title in the future, since the filename/line number might change
             getProjectId: options.getProjectId,
             ignoreAlreadyLinked: true,
           });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mermaidchart/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "description": "Access the MermaidChart services with OAuth and type safety.",
   "browser": "dist/bundle.iife.js",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       '@mermaidchart/sdk':
-        specifier: workspace:^
+        specifier: ^0.2.1-alpha.0
         version: link:../sdk
       commander:
         specifier: ^11.1.0


### PR DESCRIPTION
This is the initial public release of the `@mermaidchart/cli`.

It's still using an alpha version of the `@mermaidchart/sdk` library, since it relies on a feature that isn't in the latest `@mermaidchart/sdk` release.

---

As a quick fix, I've also added a default title for diagrams are linked from markdown files, e.g. `npx @mermaidchart/cli link folder/to/my-markdown-file.md` will title the diagrams as `my-markdown-file.md:123`.