### PR TITLE
fix(cli): improve handling of Windows CRLF line endings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,9 @@ jobs:
       matrix:
         node: ['18.18.x']
         pkg: ['sdk', 'cli']
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on:
-      labels: ubuntu-latest
+      labels: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -390,8 +390,10 @@ describe('link', () => {
     expect(file).toMatch(idLineRegex);
     // other than the added `id: xxxx` field, everything else should be identical,
     // although in practice, we'd expect some formatting changes
-    expect(file.replace(idLineRegex, '')).toStrictEqual(
-      await readFile(UNUSUAL_MARKDOWN_FILE, { encoding: 'utf8' }),
+    //
+    // We also normalize line endings to LF to avoid issues with CRLF on Windows
+    expect(file.replace(idLineRegex, '').replaceAll('\r\n', '\n')).toStrictEqual(
+      (await readFile(UNUSUAL_MARKDOWN_FILE, { encoding: 'utf8' })).replaceAll('\r\n', '\n'),
     );
   });
 });

--- a/packages/cli/src/frontmatter.spec.ts
+++ b/packages/cli/src/frontmatter.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { extractFrontMatter } from './frontmatter.js';
+
+describe('extractFrontMatter()', () => {
+  it(String.raw`should handle \r\n (␍␊)`, () => {
+    const text = '---\r\nid: test\r\n---\r\ninfo\r\n';
+    const result = extractFrontMatter(text);
+    expect(result.metadata.id).toBe('test');
+  });
+});

--- a/packages/cli/src/frontmatter.ts
+++ b/packages/cli/src/frontmatter.ts
@@ -3,7 +3,7 @@
  */
 import { parseDocument, type Document, YAMLMap, isMap } from 'yaml';
 
-const frontMatterRegex = /^-{3}\s*[\n\r](.*?)[\n\r]-{3}\s*[\n\r]+/s;
+const frontMatterRegex = /^-{3}\s*[\n\r](.*?[\n\r])-{3}\s*[\n\r]+/s;
 const urlIDRegex = /(?<baseURL>.*)\/d\/(?<documentID>[\w-]+)/;
 
 type UrlID = `${string}/d/${string}`;


### PR DESCRIPTION
Fixes a regex that was incorrectly breaking up `'\r\n'`/CRLF/␍␊ line-breaks (commonly used in Windows OSes) to just plain `'\r'`. And it seems like the YAML library we're using: https://www.npmjs.com/package/yaml seems to not register just `\r` as a line-break (although the [YAML Spec v1.2.2 § 5.4 Line Break Characters](https://yaml.org/spec/1.2.2/#line-break-characters) does seem to say that either `\r`, `'\n'` or `'\r\n'` can be used as a line break).

On Windows, files are normally checked-out with `git config core.autocrlf true`, which will replace `'\n'`/LF/␊ chars with `'\r\n'`/CRLF/␍␊ chars. We should also handle this in our unit tests, otherwise tests will fail on Windows.
