### PR TITLE
AT- 416 Added functionality to fetch PR title & description from Mermaid AI via pr-summary endpoint

### DIFF
--- a/.changeset/calm-berries-check.md
+++ b/.changeset/calm-berries-check.md
@@ -2,4 +2,4 @@
 '@mermaidchart/sdk': patch
 ---
 
-Add a suggestPrSummary method to the SDK that generates PR details based on code changes, including the branch name, title, commit message, and description.
+Add a suggestPrSummary method to the SDK that generates PR details based on Mermaid diagram changes, including the branch name, title, commit message, and description.

--- a/.changeset/calm-berries-check.md
+++ b/.changeset/calm-berries-check.md
@@ -1,0 +1,5 @@
+---
+'@mermaidchart/sdk': patch
+---
+
+Add a suggestPrSummary method to the SDK that generates PR details based on code changes, including the branch name, title, commit message, and description.

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -242,3 +242,28 @@ describe('repairDiagram', () => {
     }
   }, 60000); // 60 seconds timeout for AI repair operations
 });
+
+describe('suggestPrSummary', () => {
+  it('should generate PR summary from diagram differences', async () => {
+    const originalDiagram = `flowchart TD\n A[Start] --> B[Process]\n B --> C[End]`;
+    const editedDiagram = `flowchart TD\n A[Start] --> B[Process]\n B --> D[Validate]\n D --> C[End]`;
+
+    try {
+      const result = await client.suggestPrSummary({
+        originalDiagram,
+        editedDiagram,
+      });
+
+      // Verify response structure
+      expect(result).toHaveProperty('title');
+      expect(result).toHaveProperty('description');
+      expect(result).toHaveProperty('branchName');
+      expect(result).toHaveProperty('commitMessage');
+    } catch (error) {
+      if (error instanceof AICreditsLimitExceededError) {
+        return; // Credits exceeded is acceptable for E2E test
+      }
+      throw error;
+    }
+  }, 60000); // 60 seconds timeout for AI operations
+});

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -171,4 +171,42 @@ describe('MermaidChart', () => {
       ).rejects.toThrow(AICreditsLimitExceededError);
     });
   });
+
+  describe('#mermaidPrSuggestion', () => {
+    beforeEach(async () => {
+      await client.setAccessToken('test-access-token');
+    });
+
+    it('should return title and description from diagram diff', async () => {
+      vi.spyOn(client, 'mermaidPrSuggestion').mockResolvedValue({
+        title: 'Add validation step to flowchart',
+        description: '## What changed\n- Added node C',
+      });
+
+      const result = await client.mermaidPrSuggestion({
+        originalDiagram: 'flowchart TD\n  A --> B',
+        editedDiagram: 'flowchart TD\n  A --> B\n  B --> C[Validate]',
+      });
+
+      expect(result.title).toContain('validation');
+      expect(result.description).toContain('What changed');
+    });
+
+    it('should throw AICreditsLimitExceededError on 402', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.spyOn((client as any).axios, 'post').mockRejectedValue({
+        response: {
+          status: 402,
+          data: 'AI credits limit exceeded',
+        },
+      });
+
+      await expect(
+        client.mermaidPrSuggestion({
+          originalDiagram: 'flowchart TD\n  A --> B',
+          editedDiagram: 'flowchart TD\n  A --> B\n  B --> C',
+        }),
+      ).rejects.toThrow(AICreditsLimitExceededError);
+    });
+  });
 });

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -182,6 +182,8 @@ describe('MermaidChart', () => {
       const jsonResponse = {
         title: 'Add validation step to flowchart',
         description: '## What changed\n- Added node C',
+        branchName: 'feature/flowchart-validation',
+        commitMessage: 'Add validation node C',
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MermaidChart } from './index.js';
 import { AICreditsLimitExceededError } from './errors.js';
 import type { AuthorizationData } from './types.js';
+import { URLS } from './urls.js';
 
 import { OAuth2Client } from '@badgateway/oauth2-client';
 
@@ -172,27 +173,35 @@ describe('MermaidChart', () => {
     });
   });
 
-  describe('#mermaidPrSuggestion', () => {
+  describe('#suggestPrSummary', () => {
     beforeEach(async () => {
       await client.setAccessToken('test-access-token');
     });
 
-    it('should return title and description from diagram diff', async () => {
-      vi.spyOn(client, 'mermaidPrSuggestion').mockResolvedValue({
+    it('should POST to the pr-summary endpoint with the request body and return response.data', async () => {
+      const jsonResponse = {
         title: 'Add validation step to flowchart',
         description: '## What changed\n- Added node C',
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const postSpy = vi.spyOn((client as any).axios, 'post').mockResolvedValue({
+        data: jsonResponse,
       });
 
-      const result = await client.mermaidPrSuggestion({
+      const requestBody = {
         originalDiagram: 'flowchart TD\n  A --> B',
         editedDiagram: 'flowchart TD\n  A --> B\n  B --> C[Validate]',
-      });
+      };
 
-      expect(result.title).toContain('validation');
-      expect(result.description).toContain('What changed');
+      const result = await client.suggestPrSummary(requestBody);
+
+      expect(postSpy).toHaveBeenCalledWith(URLS.rest.openai.prSummary, requestBody);
+      expect(result).toEqual(jsonResponse);
     });
 
     it('should throw AICreditsLimitExceededError on 402', async () => {
+      // Mock the underlying axios call so the error mapping in suggestPrSummary is exercised.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.spyOn((client as any).axios, 'post').mockRejectedValue({
         response: {
@@ -202,7 +211,7 @@ describe('MermaidChart', () => {
       });
 
       await expect(
-        client.mermaidPrSuggestion({
+        client.suggestPrSummary({
           originalDiagram: 'flowchart TD\n  A --> B',
           editedDiagram: 'flowchart TD\n  A --> B\n  B --> C',
         }),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -334,7 +334,7 @@ export class MermaidChart {
 
   /**
    * Suggests a pull request title and body (markdown) from a before/after diagram diff (Mermaid AI).
-   * The response also include  `branchName` and `commitMessage`.
+   * The response also includes `branchName` and `commitMessage`.
    *
    * @param request - `originalDiagram` and `editedDiagram` only
    * @throws {@link AICreditsLimitExceededError} if credits limit exceeded (HTTP 402)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,8 +19,8 @@ import type {
   MCUser,
   RepairDiagramRequest,
   RepairDiagramResponse,
-  MermaidPrSuggestionRequest,
-  MermaidPrSuggestionResponse,
+  PrSummaryRequest,
+  PrSummaryResponse,
   AICreditsUsage,
 } from './types.js';
 import { URLS } from './urls.js';
@@ -338,11 +338,9 @@ export class MermaidChart {
    * @param request - `originalDiagram` and `editedDiagram` only
    * @throws {@link AICreditsLimitExceededError} if credits limit exceeded (HTTP 402)
    */
-  public async mermaidPrSuggestion(
-    request: MermaidPrSuggestionRequest,
-  ): Promise<MermaidPrSuggestionResponse> {
+  public async suggestPrSummary(request: PrSummaryRequest): Promise<PrSummaryResponse> {
     try {
-      const response = await this.axios.post<MermaidPrSuggestionResponse>(
+      const response = await this.axios.post<PrSummaryResponse>(
         URLS.rest.openai.prSummary,
         request,
       );

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -334,6 +334,7 @@ export class MermaidChart {
 
   /**
    * Suggests a pull request title and body (markdown) from a before/after diagram diff (Mermaid AI).
+   * The response also include  `branchName` and `commitMessage`.
    *
    * @param request - `originalDiagram` and `editedDiagram` only
    * @throws {@link AICreditsLimitExceededError} if credits limit exceeded (HTTP 402)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -338,7 +338,9 @@ export class MermaidChart {
    * @param request - `originalDiagram` and `editedDiagram` only
    * @throws {@link AICreditsLimitExceededError} if credits limit exceeded (HTTP 402)
    */
-  public async mermaidPrSuggestion(request: MermaidPrSuggestionRequest): Promise<MermaidPrSuggestionResponse> {
+  public async mermaidPrSuggestion(
+    request: MermaidPrSuggestionRequest,
+  ): Promise<MermaidPrSuggestionResponse> {
     try {
       const response = await this.axios.post<MermaidPrSuggestionResponse>(
         URLS.rest.openai.prSummary,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -19,6 +19,8 @@ import type {
   MCUser,
   RepairDiagramRequest,
   RepairDiagramResponse,
+  MermaidPrSuggestionRequest,
+  MermaidPrSuggestionResponse,
   AICreditsUsage,
 } from './types.js';
 import { URLS } from './urls.js';
@@ -322,6 +324,24 @@ export class MermaidChart {
     try {
       const response = await this.axios.post<RepairDiagramResponse>(
         URLS.rest.openai.repair,
+        request,
+      );
+      return response.data;
+    } catch (error: unknown) {
+      throwIfAICreditsExceeded(error);
+    }
+  }
+
+  /**
+   * Suggests a pull request title and body (markdown) from a before/after diagram diff (Mermaid AI).
+   *
+   * @param request - `originalDiagram` and `editedDiagram` only
+   * @throws {@link AICreditsLimitExceededError} if credits limit exceeded (HTTP 402)
+   */
+  public async mermaidPrSuggestion(request: MermaidPrSuggestionRequest): Promise<MermaidPrSuggestionResponse> {
+    try {
+      const response = await this.axios.post<MermaidPrSuggestionResponse>(
+        URLS.rest.openai.prSummary,
         request,
       );
       return response.data;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -105,11 +105,13 @@ export interface PrSummaryRequest {
 }
 
 /**
- * Public response: suggested PR title and markdown description
+ * Public response: suggested PR title and markdown description, branch name, and commit message.
  */
 export interface PrSummaryResponse {
   title: string;
   description: string;
+  branchName?: string;
+  commitMessage?: string;
 }
 
 /**

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -97,9 +97,9 @@ export interface RepairDiagramRequest {
 }
 
 /**
- * Only the two diagram versions are sent; the server derives user plan and usage from the session.
+ * Only the two diagram versions are sent; the server derives user plan and usage from the auth context provided by the access token.
  */
-export interface MermaidPrSuggestionRequest {
+export interface PrSummaryRequest {
   originalDiagram: string;
   editedDiagram: string;
 }
@@ -107,7 +107,7 @@ export interface MermaidPrSuggestionRequest {
 /**
  * Public response: suggested PR title and markdown description
  */
-export interface MermaidPrSuggestionResponse {
+export interface PrSummaryResponse {
   title: string;
   description: string;
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -97,6 +97,22 @@ export interface RepairDiagramRequest {
 }
 
 /**
+ * Only the two diagram versions are sent; the server derives user plan and usage from the session.
+ */
+export interface MermaidPrSuggestionRequest {
+  originalDiagram: string;
+  editedDiagram: string;
+}
+
+/**
+ * Public response: suggested PR title and markdown description
+ */
+export interface MermaidPrSuggestionResponse {
+  title: string;
+  description: string;
+}
+
+/**
  * Request parameters for chatting with the Mermaid AI about a diagram.
  */
 export interface DiagramChatRequest {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -110,8 +110,8 @@ export interface PrSummaryRequest {
 export interface PrSummaryResponse {
   title: string;
   description: string;
-  branchName?: string;
-  commitMessage?: string;
+  branchName: string;
+  commitMessage: string;
 }
 
 /**

--- a/packages/sdk/src/urls.ts
+++ b/packages/sdk/src/urls.ts
@@ -41,6 +41,7 @@ export const URLS = {
     },
     openai: {
       repair: `/rest-api/openai/repair`,
+      prSummary: `/rest-api/openai/pr-summary`,
       chat: `/rest-api/openai/chat`,
     },
   },


### PR DESCRIPTION
Introduces support for calling the` /rest-api/openai/pr-summary` endpoint with original and modified Mermaid diagrams to generate suggested PR **titles and descriptions.**

Enables Mermaid MCP and other SDK consumers to build automated PR copy generation from diagram diffs.