### PR TITLE
PLUG-111- Added Analytics Id For Mermaid User

### DIFF
--- a/.changeset/nice-buttons-happen.md
+++ b/.changeset/nice-buttons-happen.md
@@ -1,0 +1,5 @@
+---
+'@mermaidchart/sdk': patch
+---
+
+Added the optional analyticsID for MCUser so we can track the evetns on mermaid mcp server

--- a/.changeset/nice-buttons-happen.md
+++ b/.changeset/nice-buttons-happen.md
@@ -2,4 +2,4 @@
 '@mermaidchart/sdk': patch
 ---
 
-Added required analyticsID to MCUser so consumers (e.g. mermaid-mcp) can use the stable Mixpanel identity
+Added analyticsID, avatarUrl, mermaidTheme, and mermaidLook to MCUser.

--- a/.changeset/nice-buttons-happen.md
+++ b/.changeset/nice-buttons-happen.md
@@ -2,4 +2,4 @@
 '@mermaidchart/sdk': patch
 ---
 
-Added the optional analyticsID for MCUser so we can track the evetns on mermaid mcp server
+Added required analyticsID to MCUser so consumers (e.g. mermaid-mcp) can use the stable Mixpanel identity

--- a/.changeset/nice-buttons-happen.md
+++ b/.changeset/nice-buttons-happen.md
@@ -2,4 +2,4 @@
 '@mermaidchart/sdk': patch
 ---
 
-Added analyticsID, avatarUrl, mermaidTheme, and mermaidLook to MCUser.
+Add `analyticsID`, `avatarUrl`, `mermaidTheme`, and `mermaidLook` return types to `getUser()`

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -60,6 +60,7 @@ const mockedMCUser = {
   fullName: 'My Test User',
   emailAddress: 'my-test-user@test.invalid',
   analyticsID: '00000000-0000-0000-0000-0000000000aa',
+  avatarUrl: null,
 } as const satisfies MCUser;
 const mockedProjects = [
   {

--- a/packages/cli/src/commander.test.ts
+++ b/packages/cli/src/commander.test.ts
@@ -59,6 +59,7 @@ beforeAll(async () => {
 const mockedMCUser = {
   fullName: 'My Test User',
   emailAddress: 'my-test-user@test.invalid',
+  analyticsID: '00000000-0000-0000-0000-0000000000aa',
 } as const satisfies MCUser;
 const mockedProjects = [
   {

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -79,6 +79,9 @@ describe('getUser', () => {
     const user = await client.getUser();
 
     expect(user).toHaveProperty('emailAddress');
+    expect(user).toHaveProperty('analyticsID');
+    expect(typeof user.analyticsID).toBe('string');
+    expect(user.analyticsID.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -82,6 +82,13 @@ describe('getUser', () => {
     expect(user).toHaveProperty('analyticsID');
     expect(typeof user.analyticsID).toBe('string');
     expect(user.analyticsID.length).toBeGreaterThan(0);
+    expect(user.avatarUrl === null || typeof user.avatarUrl === 'string').toBe(true);
+    if (user.mermaidTheme !== undefined) {
+      expect(typeof user.mermaidTheme).toBe('string');
+    }
+    if (user.mermaidLook !== undefined) {
+      expect(typeof user.mermaidLook).toBe('string');
+    }
   });
 });
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -38,6 +38,7 @@ describe('MermaidChart', () => {
         fullName: 'Test User',
         emailAddress: 'test@invalid.invalid',
         analyticsID: '00000000-0000-0000-0000-0000000000aa',
+        avatarUrl: null,
       };
     });
   });

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -37,6 +37,7 @@ describe('MermaidChart', () => {
       return {
         fullName: 'Test User',
         emailAddress: 'test@invalid.invalid',
+        analyticsID: '00000000-0000-0000-0000-0000000000aa',
       };
     });
   });

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -23,6 +23,9 @@ export interface MCUser {
   fullName: string;
   emailAddress: string;
   analyticsID: string;
+  avatarUrl: string | null;
+  mermaidTheme?: string;
+  mermaidLook?: string;
 }
 
 export interface AICreditsUsage {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -22,7 +22,7 @@ export interface AuthState {
 export interface MCUser {
   fullName: string;
   emailAddress: string;
-  analyticsID?: string;
+  analyticsID: string;
 }
 
 export interface AICreditsUsage {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -22,7 +22,7 @@ export interface AuthState {
 export interface MCUser {
   fullName: string;
   emailAddress: string;
-  analyticsID: string;
+  analyticsID?: string;
 }
 
 export interface AICreditsUsage {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -22,6 +22,7 @@ export interface AuthState {
 export interface MCUser {
   fullName: string;
   emailAddress: string;
+  analyticsID: string;
 }
 
 export interface AICreditsUsage {


### PR DESCRIPTION
Add the `analyticsID` field to the `MCUser` type so the SDK's `getUser()` exposes the Mermaid Chart analytics ID that the `/rest-api/users/me` endpoint already returns. This is a type-only change (no runtime behavior changes) that lets consumers like the MCP server identify a stable per-user ID for analytics instead of treating every event as a new user.